### PR TITLE
Manually specify labels for cm

### DIFF
--- a/src/metriculous/evaluators/_classification_figures_bokeh.py
+++ b/src/metriculous/evaluators/_classification_figures_bokeh.py
@@ -141,7 +141,7 @@ def _bokeh_confusion_matrix(
     """
 
     def figure() -> Figure:
-        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(len(class_names)))
+        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(len(class_names))))
         cm_normalized = cm.astype("float") / cm.sum()
         cm_normalized_by_pred = cm.astype("float") / cm.sum(axis=0, keepdims=True)
         cm_normalized_by_true = cm.astype("float") / cm.sum(axis=1, keepdims=True)

--- a/src/metriculous/evaluators/_classification_figures_bokeh.py
+++ b/src/metriculous/evaluators/_classification_figures_bokeh.py
@@ -141,7 +141,7 @@ def _bokeh_confusion_matrix(
     """
 
     def figure() -> Figure:
-        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(y_true.max() + 1)))
+        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(len(class_names)))
         cm_normalized = cm.astype("float") / cm.sum()
         cm_normalized_by_pred = cm.astype("float") / cm.sum(axis=0, keepdims=True)
         cm_normalized_by_true = cm.astype("float") / cm.sum(axis=1, keepdims=True)

--- a/src/metriculous/evaluators/_classification_figures_bokeh.py
+++ b/src/metriculous/evaluators/_classification_figures_bokeh.py
@@ -141,7 +141,7 @@ def _bokeh_confusion_matrix(
     """
 
     def figure() -> Figure:
-        cm = sklmetrics.confusion_matrix(y_true, y_pred)
+        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(y_true.max() + 1))
         cm_normalized = cm.astype("float") / cm.sum()
         cm_normalized_by_pred = cm.astype("float") / cm.sum(axis=0, keepdims=True)
         cm_normalized_by_true = cm.astype("float") / cm.sum(axis=1, keepdims=True)

--- a/src/metriculous/evaluators/_classification_figures_bokeh.py
+++ b/src/metriculous/evaluators/_classification_figures_bokeh.py
@@ -141,7 +141,7 @@ def _bokeh_confusion_matrix(
     """
 
     def figure() -> Figure:
-        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(y_true.max() + 1))
+        cm = sklmetrics.confusion_matrix(y_true, y_pred, labels=list(range(y_true.max() + 1)))
         cm_normalized = cm.astype("float") / cm.sum()
         cm_normalized_by_pred = cm.astype("float") / cm.sum(axis=0, keepdims=True)
         cm_normalized_by_true = cm.astype("float") / cm.sum(axis=1, keepdims=True)

--- a/src/metriculous/evaluators/_classification_figures_bokeh.py
+++ b/src/metriculous/evaluators/_classification_figures_bokeh.py
@@ -146,6 +146,10 @@ def _bokeh_confusion_matrix(
         cm_normalized_by_pred = cm.astype("float") / cm.sum(axis=0, keepdims=True)
         cm_normalized_by_true = cm.astype("float") / cm.sum(axis=1, keepdims=True)
 
+        cm_normalized = np.nan_to_num(cm_normalized)
+        cm_normalized_by_pred = np.nan_to_num(cm_normalized_by_pred)
+        cm_normalized_by_true = np.nan_to_num(cm_normalized_by_true)
+
         predicted = list()
         actual = list()
         count = list()


### PR DESCRIPTION
When y_true contains `[ 0  1  2  3  5  6  7  8  9 11 12]` and y_pred `[0 1 3 5 6 8 9]` ie. my model does not predict any of the classes 2, 4, ...


I get this error:

```
~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/__init__.py in compare_classifiers(ground_truth, model_predictions, model_names, sample_weights, class_names, one_vs_all_quantities, one_vs_all_figures, top_n_accuracies, filter_quantities, filter_figures, primary_metric, simulated_class_distribution, class_label_rotation_x, class_label_rotation_y)
     48 ) -> Comparison:
     49 
---> 50     return compare(
     51         evaluator=ClassificationEvaluator(
     52             class_names=class_names,

~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/_comparison.py in compare(evaluator, ground_truth, model_predictions, model_names, sample_weights)
    169         assert_that(model_names).is_length(len(model_predictions))
    170 
--> 171     model_evaluations = [
    172         evaluator.evaluate(
    173             ground_truth,

~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/_comparison.py in <listcomp>(.0)
    170 
    171     model_evaluations = [
--> 172         evaluator.evaluate(
    173             ground_truth,
    174             model_prediction=pred,

~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/evaluators/_classification_evaluator.py in evaluate(self, ground_truth, model_prediction, model_name, sample_weights)
    177 
    178         # === Figures ==================================================================
--> 179         unfiltered_lazy_figures = self._lazy_figures(
    180             model_name,
    181             data=data,

~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/evaluators/_classification_evaluator.py in _lazy_figures(self, model_name, data, maybe_sample_weights, class_names)
    276                 (
    277                     "Confusion Matrix",
--> 278                     _bokeh_confusion_matrix(
    279                         y_true=y_true,
    280                         y_pred=y_pred,

~/Library/Caches/pypoetry/virtualenvs/document-classification-ReJIVt9a-py3.8/lib/python3.8/site-packages/metriculous/evaluators/_classification_figures_bokeh.py in _bokeh_confusion_matrix(y_true, y_pred, class_names, title_rows, x_label_rotation, y_label_rotation)
    177             predicted.append(j_class)
    178             actual.append(i_class)
--> 179             count.append(cm[i, j])
    180             normalized.append(cm_normalized[i, j])
    181             normalized_by_pred.append(cm_normalized_by_pred[i, j])

IndexError: index 11 is out of bounds for axis 1 with size 11
```